### PR TITLE
fix event name streamingStatusChange

### DIFF
--- a/slobs_websocket/services/streaming_service.py
+++ b/slobs_websocket/services/streaming_service.py
@@ -4,7 +4,7 @@ class StreamingService(BasicEventService):
     """
         Events
     """
-    __events__ = ["streamingStatusChanged"]
+    __events__ = ["streamingStatusChange"]
 
     """
         Methods


### PR DESCRIPTION
Hi, this PR fixes the event name for [streamingStatusChange](https://stream-labs.github.io/streamlabs-desktop-api-docs/docs/classes/_streaming_streaming_.streamingservice.html).

Thanks.